### PR TITLE
add showControls=false

### DIFF
--- a/views/etherpad.jade
+++ b/views/etherpad.jade
@@ -4,7 +4,7 @@ block content
   div(class="container")
     div(id="everything")
       div(id="editor" class="full-height-pane left-pane")
-        iframe(src="http://etherpad.net/p/" + etherpadId + "?showChat=false" height="500px" width="460px" data-etherpad-id=etherpadId)
+        iframe(src="http://etherpad.net/p/" + etherpadId + "?showChat=false&showControls=false" height="500px" width="460px" data-etherpad-id=etherpadId)
       div(id="render" class="full-height-pane right-pane")
         div.render-pane-header
           .btn-group


### PR DESCRIPTION
This will hide the formatting toolbar, which IMO doesn't make sense